### PR TITLE
Use options manager for default row height and column width

### DIFF
--- a/src/Spout/Writer/Common/Entity/Worksheet.php
+++ b/src/Spout/Writer/Common/Entity/Worksheet.php
@@ -23,6 +23,9 @@ class Worksheet
     /** @var int Index of the last written row */
     private $lastWrittenRowIndex;
 
+    /** @var bool has the sheet data header been written */
+    private $sheetDataStarted = false;
+
     /**
      * Worksheet constructor.
      *
@@ -36,6 +39,7 @@ class Worksheet
         $this->externalSheet = $externalSheet;
         $this->maxNumColumns = 0;
         $this->lastWrittenRowIndex = 0;
+        $this->sheetDataStarted = false;
     }
 
     /**
@@ -109,5 +113,21 @@ class Worksheet
     {
         // sheet index is zero-based, while ID is 1-based
         return $this->externalSheet->getIndex() + 1;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getSheetDataStarted()
+    {
+        return $this->sheetDataStarted;
+    }
+
+    /**
+     * @param bool $sheetDataStarted
+     */
+    public function setSheetDataStarted($sheetDataStarted)
+    {
+        $this->sheetDataStarted = $sheetDataStarted;
     }
 }

--- a/src/Spout/Writer/WriterMultiSheetsAbstract.php
+++ b/src/Spout/Writer/WriterMultiSheetsAbstract.php
@@ -142,22 +142,28 @@ abstract class WriterMultiSheetsAbstract extends WriterAbstract
 
     /**
      * @param float $width
-     * @throws WriterNotOpenedException
+     * @throws WriterAlreadyOpenedException
      */
     public function setDefaultColumnWidth(float $width)
     {
-        $this->throwIfWorkbookIsNotAvailable();
-        $this->workbookManager->setDefaultColumnWidth($width);
+        $this->throwIfWriterAlreadyOpened('Writer must be configured before opening it.');
+        $this->optionsManager->setOption(
+            Options::DEFAULT_COLUMN_WIDTH,
+            $width
+        );
     }
 
     /**
      * @param float $height
-     * @throws WriterNotOpenedException
+     * @throws WriterAlreadyOpenedException
      */
     public function setDefaultRowHeight(float $height)
     {
-        $this->throwIfWorkbookIsNotAvailable();
-        $this->workbookManager->setDefaultRowHeight($height);
+        $this->throwIfWriterAlreadyOpened('Writer must be configured before opening it.');
+        $this->optionsManager->setOption(
+          Options::DEFAULT_ROW_HEIGHT,
+          $height
+      );
     }
 
     /**

--- a/src/Spout/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Spout/Writer/XLSX/Manager/WorksheetManager.php
@@ -65,9 +65,6 @@ EOD;
     /** @var InternalEntityFactory Factory to create entities */
     private $entityFactory;
 
-    /** @var bool Whether rows have been written */
-    private $hasWrittenRows = false;
-
     /**
      * WorksheetManager constructor.
      *
@@ -122,6 +119,9 @@ EOD;
         $worksheet->setFilePointer($sheetFilePointer);
 
         \fwrite($sheetFilePointer, self::SHEET_XML_FILE_HEADER);
+        \fwrite($sheetFilePointer, $this->getXMLFragmentForDefaultCellSizing());
+        \fwrite($sheetFilePointer, $this->getXMLFragmentForColumnWidths());
+        \fwrite($sheetFilePointer, '<sheetData>');
     }
 
     /**
@@ -162,12 +162,6 @@ EOD;
     private function addNonEmptyRow(Worksheet $worksheet, Row $row)
     {
         $sheetFilePointer = $worksheet->getFilePointer();
-        if (!$this->hasWrittenRows) {
-            fwrite($sheetFilePointer, $this->getXMLFragmentForDefaultCellSizing());
-            fwrite($sheetFilePointer, $this->getXMLFragmentForColumnWidths());
-            fwrite($sheetFilePointer, '<sheetData>');
-        }
-
         $rowStyle = $row->getStyle();
         $rowIndexOneBased = $worksheet->getLastWrittenRowIndex() + 1;
         $numCells = $row->getNumCells();
@@ -185,7 +179,6 @@ EOD;
         if ($wasWriteSuccessful === false) {
             throw new IOException("Unable to write data in {$worksheet->getFilePath()}");
         }
-        $this->hasWrittenRows = true;
     }
 
     /**
@@ -324,9 +317,7 @@ EOD;
             return;
         }
 
-        if ($this->hasWrittenRows) {
-            \fwrite($worksheetFilePointer, '</sheetData>');
-        }
+        \fwrite($worksheetFilePointer, '</sheetData>');
         \fwrite($worksheetFilePointer, '</worksheet>');
         \fclose($worksheetFilePointer);
     }

--- a/src/Spout/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Spout/Writer/XLSX/Manager/WorksheetManager.php
@@ -119,9 +119,22 @@ EOD;
         $worksheet->setFilePointer($sheetFilePointer);
 
         \fwrite($sheetFilePointer, self::SHEET_XML_FILE_HEADER);
-        \fwrite($sheetFilePointer, $this->getXMLFragmentForDefaultCellSizing());
-        \fwrite($sheetFilePointer, $this->getXMLFragmentForColumnWidths());
-        \fwrite($sheetFilePointer, '<sheetData>');
+    }
+
+    /**
+     * Writes the sheet data header
+     * 
+     * @param Worksheet $worksheet The worksheet to add the row to
+     * @return void
+     */
+    private function ensureSheetDataStated(Worksheet $worksheet) {
+        if (!$worksheet->getSheetDataStarted()) {
+          $worksheetFilePointer = $worksheet->getFilePointer();
+          \fwrite($worksheetFilePointer, $this->getXMLFragmentForDefaultCellSizing());
+          \fwrite($worksheetFilePointer, $this->getXMLFragmentForColumnWidths());
+          \fwrite($worksheetFilePointer, '<sheetData>');
+          $worksheet->setSheetDataStarted(true);
+        }
     }
 
     /**
@@ -161,6 +174,7 @@ EOD;
      */
     private function addNonEmptyRow(Worksheet $worksheet, Row $row)
     {
+        $this->ensureSheetDataStated($worksheet);
         $sheetFilePointer = $worksheet->getFilePointer();
         $rowStyle = $row->getStyle();
         $rowIndexOneBased = $worksheet->getLastWrittenRowIndex() + 1;
@@ -316,7 +330,7 @@ EOD;
         if (!\is_resource($worksheetFilePointer)) {
             return;
         }
-
+        $this->ensureSheetDataStated($worksheet);
         \fwrite($worksheetFilePointer, '</sheetData>');
         \fwrite($worksheetFilePointer, '</worksheet>');
         \fclose($worksheetFilePointer);


### PR DESCRIPTION
Found you delayed the `\fwrite($sheetFilePointer, '<sheetData>');` in `WorksheetManager`.  But therefore invalid sheets will be generated if you simply call `$writer->addNewSheetAndMakeItCurrent()` without adding data to the worksheet. 

in my opinion `startSheet` should look like this

```
public function startSheet(Worksheet $worksheet)
{
  ...
  \fwrite($sheetFilePointer, self::SHEET_XML_FILE_HEADER);
  \fwrite($sheetFilePointer, $this->getXMLFragmentForDefaultCellSizing());
  \fwrite($sheetFilePointer, $this->getXMLFragmentForColumnWidths());
  \fwrite($sheetFilePointer, '<sheetData>');
```

But then there is no time to call `$writer->setDefaultColumnWidth` or `$writer->setDefaultRowHeight` before the first sheet is created (by `WriterMultiSheetsAbstract->openWriter()`).

Therefore i have refactored `setDefaultColumnWidth` and `setDefaultRowHeight` to  use the `OptionsManager` like `writer->setTempFolder`. I believe setting default values before the writer is opened is the easier way.